### PR TITLE
feat: add Explore sections and example line chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "@inertiajs/progress": "^0.2.4",
     "@mdi/font": "^5.9.55",
     "axios": "^0.21.1",
+    "chart.js": "^2.9.4",
     "lodash": "^4.17.21",
     "mapbox-gl": "^2.1.1",
     "vue": "^2.6.12",
+    "vue-chartjs": "^3.5.1",
     "vuetify": "^2.4.3"
   }
 }

--- a/resources/js/Pages/Explore.vue
+++ b/resources/js/Pages/Explore.vue
@@ -5,24 +5,55 @@
   >
     <template #sheet-collapsed>
       <v-card-title class="px-1">
-        <v-btn icon>
+        <v-btn
+          icon
+          @click="goToPrevPane"
+        >
+          <span class="d-sr-only">Previous data</span>
           <v-icon>mdi-chevron-left</v-icon>
         </v-btn>
-        <div class="flex-grow-1 mx-1">
-          Sale price
+        <div
+          class="mx-1 overflow-hidden"
+          style="flex: 1 1 0"
+        >
+          <v-window
+            v-model="currentPane"
+            vertical
+          >
+            <v-window-item
+              v-for="(pane, title) in panes"
+              :key="title"
+            >
+              <div class="text-truncate">
+                {{ title }}
+              </div>
+            </v-window-item>
+          </v-window>
         </div>
-        <v-btn icon>
+        <v-btn
+          icon
+          @click="goToNextPane"
+        >
+          <span class="d-sr-only">Next data</span>
           <v-icon>mdi-chevron-right</v-icon>
         </v-btn>
       </v-card-title>
     </template>
 
     <template #sheet-expanded>
-      <v-card-text class="mt-n1 pt-0 pb-5">
-        <p>Some graphs and such go here.</p>
-
-        <div style="background-color: #ccc; padding-top: 56.25%;" />
-      </v-card-text>
+      <v-window
+        v-model="currentPane"
+        class="mt-n6"
+      >
+        <v-window-item
+          v-for="(pane, title) in panes"
+          :key="title"
+        >
+          <v-card-text>
+            <component :is="pane" />
+          </v-card-text>
+        </v-window-item>
+      </v-window>
     </template>
   </lp-bottom-sheet>
 </template>
@@ -31,6 +62,14 @@
 import Layout from '../Shared/Layouts/Layout.vue';
 import MapSheetLayout from '../Shared/Layouts/MapSheetLayout.vue';
 import LPBottomSheet from '../Shared/LPBottomSheet.vue';
+
+// panes
+import Alteration from './Explore/Alteration.vue';
+import LandUse from './Explore/LandUse.vue';
+import NewConstruction from './Explore/NewConstruction.vue';
+import SalePrices from './Explore/SalePrices.vue';
+import Zoning from './Explore/Zoning.vue';
+
 import uiState from '../uiState';
 
 export default {
@@ -43,12 +82,46 @@ export default {
   data() {
     return {
       isExpanded: uiState.exploreIsExpanded,
+      currentPane: uiState.exploreCurrentPane,
+      panes: {
+        'Sale Prices': SalePrices,
+        Zoning,
+        'Land Use': LandUse,
+        'New Construction Permits': NewConstruction,
+        Alteration,
+      },
     };
+  },
+
+  computed: {
+    paneCount() {
+      return Object.keys(this.panes).length;
+    },
   },
 
   methods: {
     handleToggle(newState) {
       uiState.exploreIsExpanded = newState;
+    },
+
+    goToNextPane() {
+      if (this.currentPane + 1 < this.paneCount) {
+        this.currentPane += 1;
+      } else {
+        this.currentPane = 0;
+      }
+
+      uiState.exploreCurrentPane = this.currentPane;
+    },
+
+    goToPrevPane() {
+      if (this.currentPane > 0) {
+        this.currentPane -= 1;
+      } else {
+        this.currentPane = this.paneCount - 1;
+      }
+
+      uiState.exploreCurrentPane = this.currentPane;
     },
   },
 };

--- a/resources/js/Pages/Explore/Alteration.vue
+++ b/resources/js/Pages/Explore/Alteration.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    a line plot with the count of alteration permits over the last ten years.
+    HOLD ON ON THIS FOR NOW. Census race and income.
+    I am weary about this because it changes the geometry.
+    We could allocate the census block group data to tract?
+    - Still have to figure this one out.
+  </div>
+</template>

--- a/resources/js/Pages/Explore/LandUse.vue
+++ b/resources/js/Pages/Explore/LandUse.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    A bar plot showing the rate of each land use designation by parcel.
+    (from the zoning_landuse2 table). If there are too many to show,
+    maybe show the most frequent 6-8? Whatever is most reasonable.
+  </div>
+</template>

--- a/resources/js/Pages/Explore/NewConstruction.vue
+++ b/resources/js/Pages/Explore/NewConstruction.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>A line plot with the count of new construction permits over the last ten years.</div>
+</template>

--- a/resources/js/Pages/Explore/SalePrices.vue
+++ b/resources/js/Pages/Explore/SalePrices.vue
@@ -1,0 +1,60 @@
+<template>
+  <div>
+    <p>
+      Plotted as a line chart of average home prices by year.
+      This should be for the whole area not just the zoom.
+    </p>
+    <line-chart
+      :chart-data="chartData"
+      :options="options"
+      :height="null"
+    />
+  </div>
+</template>
+
+<script>
+import LineChart from '../../Shared/LineChart.vue';
+
+export default {
+  components: {
+    LineChart,
+  },
+
+  data() {
+    return {
+      chartData: {
+        labels: [2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020],
+        datasets: [{
+          data: [80000, 150000, 175000, 180000, 200000, 190000, 210000, 250000, 260000, 320000],
+        }],
+      },
+
+      options: {
+        aspectRatio: 16 / 9,
+        scales: {
+          yAxes: [{
+            ticks: {
+              beginAtZero: true,
+              callback: (value, index) => {
+                let formatted = Math.round(value / 1000);
+
+                if (value !== 0) {
+                  formatted += 'K';
+                }
+
+                if (index === 0) {
+                  return `$${formatted}`;
+                }
+                return formatted;
+              },
+            },
+          }],
+        },
+        legend: {
+          display: false,
+        },
+      },
+    };
+  },
+};
+</script>

--- a/resources/js/Pages/Explore/Zoning.vue
+++ b/resources/js/Pages/Explore/Zoning.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>A bar plot showing the rate of each zoning designation by parcel.</div>
+</template>

--- a/resources/js/Shared/LineChart.vue
+++ b/resources/js/Shared/LineChart.vue
@@ -1,0 +1,23 @@
+<script>
+import { Line } from 'vue-chartjs';
+
+export default {
+  extends: Line,
+
+  props: {
+    chartData: {
+      type: Object,
+      default: null,
+    },
+
+    options: {
+      type: Object,
+      default: null,
+    },
+  },
+
+  mounted() {
+    this.renderChart(this.chartData, this.options);
+  },
+};
+</script>

--- a/resources/js/uiState.js
+++ b/resources/js/uiState.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 
 export default Vue.observable({
-  exploreIsExpanded: false,
+  exploreIsExpanded: true,
   layersIsExpanded: true,
+  exploreCurrentPane: 0,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,13 @@
   dependencies:
     browserslist "*"
 
+"@types/chart.js@^2.7.55":
+  version "2.9.31"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.31.tgz#e8ebc7ed18eb0e5114c69bd46ef8e0037c89d39d"
+  integrity sha512-hzS6phN/kx3jClk3iYqEHNnYIRSi4RZrIGJ8CDLjgatpHoftCezvC44uqB3o3OUm9ftU1m7sHG8+RLyPTlACrA==
+  dependencies:
+    moment "^2.10.2"
+
 "@types/clean-css@^4.2.2":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/clean-css/-/clean-css-4.2.3.tgz#12c13cc815f5e793014ee002c6324455907d851c"
@@ -1958,6 +1965,29 @@ charenc@0.0.2:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
+chart.js@^2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.4.tgz#0827f9563faffb2dc5c06562f8eb10337d5b9684"
+  integrity sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
+  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.4.1.tgz#6118bba202fe1ea79dd7f7c0f9da93467296c3b0"
+  integrity sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==
+  dependencies:
+    chartjs-color-string "^0.6.0"
+    color-convert "^1.9.3"
+
 "chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.3:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
@@ -2079,7 +2109,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4869,6 +4899,11 @@ mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moment@^2.10.2:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -7204,6 +7239,13 @@ vt-pbf@^3.1.1:
     "@mapbox/point-geometry" "0.1.0"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.0.5"
+
+vue-chartjs@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/vue-chartjs/-/vue-chartjs-3.5.1.tgz#d25e845708f7744ae51bed9d23a975f5f8fc6529"
+  integrity sha512-foocQbJ7FtveICxb4EV5QuVpo6d8CmZFmAopBppDIGKY+esJV8IJgwmEW0RexQhxqXaL/E1xNURsgFFYyKzS/g==
+  dependencies:
+    "@types/chart.js" "^2.7.55"
 
 vue-eslint-parser@^7.5.0:
   version "7.5.0"


### PR DESCRIPTION
- Add `vue-chartjs` dependency
- Add placeholder sections + working left/right nav to Explore
- Add dummy chart for Sale Prices

![Screen Shot 2021-03-12 at 12 09 30 AM](https://user-images.githubusercontent.com/1154929/110895192-44d75e80-82c7-11eb-88dd-4c6b6d02465b.png)
