### PR TITLE
Refactor and improve parcel popup [LP-57, LP-58]

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "chart.js": "^2.9.4",
     "lodash": "^4.17.21",
     "mapbox-gl": "^2.1.1",
+    "numeral": "^2.0.6",
     "vue": "^2.6.12",
     "vue-chartjs": "^3.5.1",
     "vuetify": "^2.4.3"

--- a/resources/js/Shared/ParcelFigure.vue
+++ b/resources/js/Shared/ParcelFigure.vue
@@ -10,7 +10,7 @@
       class="figure__content"
       :class="contentClass"
     >
-      {{ value || '\u2014' }}
+      {{ value ? value.toString() : '\u2014' }}
     </div>
   </figure>
 </template>
@@ -24,7 +24,7 @@ export default {
     },
 
     value: {
-      type: String,
+      type: [String, Number],
       default: null,
     },
 

--- a/resources/js/Shared/ParcelFigure.vue
+++ b/resources/js/Shared/ParcelFigure.vue
@@ -1,0 +1,42 @@
+<template>
+  <figure class="figure">
+    <figcaption
+      class="figure__description"
+      :class="descriptionClass || 'text--secondary'"
+    >
+      {{ name }}
+    </figcaption>
+    <div
+      class="figure__content"
+      :class="contentClass"
+    >
+      {{ value || '\u2014' }}
+    </div>
+  </figure>
+</template>
+
+<script>
+export default {
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+
+    value: {
+      type: String,
+      default: null,
+    },
+
+    contentClass: {
+      type: String,
+      default: null,
+    },
+
+    descriptionClass: {
+      type: String,
+      default: 'text--secondary',
+    },
+  },
+};
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5099,6 +5099,11 @@ nth-check@^1.0.2:
   dependencies:
     boolbase "~1.0.0"
 
+numeral@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/numeral/-/numeral-2.0.6.tgz#4ad080936d443c2561aed9f2197efffe25f4e506"
+  integrity sha1-StCAk21EPCVhrtnyGX7//iX05QY=
+
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"


### PR DESCRIPTION
> Closes LP-57, LP-58

- Refactor parcel popup data to use a component instead of `v-html` attributes
- Use a rudimentary cache to avoid multiple fetches for the same parcel in a session
- Add [Numeral.js](http://numeraljs.com/) to format sales figure