### PR TITLE
fix: fix initial map tiles load [LP-71]

### DIFF
--- a/app/Http/Controllers/ExploreController.php
+++ b/app/Http/Controllers/ExploreController.php
@@ -13,10 +13,10 @@ class ExploreController extends Controller
         'alteration' => 3,
     ];
 
-    public function index(string $pane = null)
+    public function index(string $pane)
     {
         return inertia('Explore', [
-            'pane' => self::PANES[$pane] ?? null,
+            'pane' => self::PANES[$pane],
         ]);
     }
 }

--- a/resources/js/Shared/Layouts/MapSheetLayout.vue
+++ b/resources/js/Shared/Layouts/MapSheetLayout.vue
@@ -42,7 +42,7 @@ export default {
   data() {
     return {
       isPopupVisible: false,
-      mapTiles: 'sales',
+      mapTiles: route().params.pane,
       parcelSourceId: 'urban-areas',
       rankPropertyMap: {
         sales: 'sale_price_adj',

--- a/resources/js/Shared/MapboxMap.vue
+++ b/resources/js/Shared/MapboxMap.vue
@@ -60,24 +60,7 @@ export default {
   watch: {
     // eslint-disable-next-line no-unused-vars
     tiles(newTiles, oldTiles) {
-      this.$emit('parcel-rank-changed', newTiles);
-      if (newTiles === 'sales') {
-        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorRankSteps);
-        return;
-      }
-      if (newTiles === 'zoning') {
-        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorZoningCategories);
-        return;
-      }
-      if (newTiles === 'alteration') {
-        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorPermitsAlterSteps);
-        return;
-      }
-      if (newTiles === 'construction') {
-        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorPermitsConstSteps);
-        return;
-      }
-      this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorNone);
+      this.showTiles(newTiles);
     },
   },
 
@@ -105,6 +88,27 @@ export default {
       clickHighlightSource.setData(emptyPolygonFeature);
     },
 
+    showTiles(tiles) {
+      this.$emit('parcel-rank-changed', tiles);
+      if (tiles === 'sales') {
+        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorRankSteps);
+        return;
+      }
+      if (tiles === 'zoning') {
+        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorZoningCategories);
+        return;
+      }
+      if (tiles === 'alteration') {
+        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorPermitsAlterSteps);
+        return;
+      }
+      if (tiles === 'construction') {
+        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorPermitsConstSteps);
+        return;
+      }
+      this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorNone);
+    },
+
     initMap() {
       const emptyPolygonFeature = {
         type: 'Feature',
@@ -127,7 +131,7 @@ export default {
         .addControl(new mapboxgl.ScaleControl());
 
       const { map } = this;
-      this.map.on('load', () => {
+      map.on('load', () => {
         // Find the ID of the first symbol layer in the map style
         const { layers } = map.getStyle();
         let targetLayerId;
@@ -206,6 +210,8 @@ export default {
           }
           this.$emit('parcel-click', { properties: parcel, coords: coordinates, feature });
         });
+
+        this.showTiles(this.tiles);
       });
     },
   },

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,9 @@ Route::get('/', function () {
 })->name('home');
 Route::inertia('/engage', 'Engage')->name('engage');
 // Route::inertia('/explore', 'Explore')->name('explore');
+Route::get('/explore', function () {
+    return redirect()->route('explore', ['pane' => 'sales']);
+});
 Route::get('/explore/{pane?}', 'ExploreController@index')->name('explore');
 Route::inertia('/layers', 'Layers')->name('layers');
 


### PR DESCRIPTION
- Always have a pane param for `explore` route (use `sales` by default)
- Use route pane param to configure map
- Show map tiles on first load instead of only after a switch