### PR TITLE
Fix iOS mobile viewport

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,7 @@ import vuetify from './plugins/vuetify';
 import '../scss/app.scss';
 import 'vuetify/dist/vuetify.min.css';
 import '@mdi/font/css/materialdesignicons.css';
+import '../scss/overrides.scss';
 import './bootstrap';
 
 // set up inertia

--- a/resources/scss/overrides.scss
+++ b/resources/scss/overrides.scss
@@ -1,0 +1,6 @@
+// override vuetify to fix mobile webkit layout
+// via https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/
+.v-application--wrap {
+  min-height: 100vh;
+  min-height: -webkit-fill-available;
+}

--- a/resources/scss/overrides.scss
+++ b/resources/scss/overrides.scss
@@ -1,6 +1,9 @@
 // override vuetify to fix mobile webkit layout
 // via https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/
-.v-application--wrap {
-  min-height: 100vh;
-  min-height: -webkit-fill-available;
+// and @supports targeting via https://github.com/postcss/postcss-100vh-fix
+@supports (-webkit-touch-callout: none) {
+  .v-application--wrap {
+    min-height: 100vh;
+    min-height: -webkit-fill-available;
+  }
 }


### PR DESCRIPTION
Collapsed bottom sheets were getting cut off in iOS browsers due to the behavior described here: https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/

- Add an overrides file to load after Vuetify css
- Target iOS with Apple-specific property in `@supports`
- Apply `-webkit-fill-available` to adjust viewport behavior