### PR TITLE
text change and unhighlight on popup close

### DIFF
--- a/resources/js/Pages/Engage.vue
+++ b/resources/js/Pages/Engage.vue
@@ -50,7 +50,7 @@
           class="purple lighten-5 rounded-lg"
         >
           <v-card-title class="justify-center pb-0">
-            Everyone
+            Explore Planning Analytics
           </v-card-title>
           <v-card-text>
             <p>Check out the planning analytics and survey&nbsp;results</p>

--- a/resources/js/Shared/Layouts/MapSheetLayout.vue
+++ b/resources/js/Shared/Layouts/MapSheetLayout.vue
@@ -10,6 +10,7 @@
     <parcel-popup
       v-show="isPopupVisible"
       ref="parcelpopup"
+      @close="closePopup"
     >
       <parcel-info
         ref="parcelinfo"
@@ -124,6 +125,9 @@ export default {
         this.$refs.parcelinfo.fetchParcel(event.properties.parcel_id);
         this.$refs.mapboxmap.highlightSource(event.feature);
       }
+    },
+    closePopup() {
+      this.$refs.mapboxmap.highlightClear();
     },
   },
 };

--- a/resources/js/Shared/ParcelPopup.vue
+++ b/resources/js/Shared/ParcelPopup.vue
@@ -178,6 +178,8 @@ export default {
         }
       }
 
+      this.$_bindSelfEvents(['open', 'close'], this.popup);
+
       if (this.marker) {
         this.marker.setPopup(this.popup);
       }
@@ -190,8 +192,29 @@ export default {
       }
     },
 
+    $_bindSelfEvents(events, emitter) {
+      // https://github.com/soal/vue-mapbox/blob/e0edd17bde5fe8d1db7f44029e0e3399e2bf35ea/src/components/UI/withSelfEvents.js
+      Object.keys(this.$listeners).forEach(eventName => {
+        if (events.includes(eventName)) {
+          emitter.on(eventName, this.$_emitSelfEvent);
+        }
+      });
+    },
+
     $_emitSelfEvent(event) {
       this.$_emitMapEvent(event, { popup: this.popup });
+    },
+
+    $_emitEvent(name, data = {}) {
+      this.$emit(name, {
+        map: this.map,
+        component: this,
+        ...data,
+      });
+    },
+
+    $_emitMapEvent(event, data = {}) {
+      this.$_emitEvent(event.type, { mapboxEvent: event, ...data });
     },
 
     remove() {

--- a/resources/js/Shared/ParcelPopup.vue
+++ b/resources/js/Shared/ParcelPopup.vue
@@ -194,7 +194,7 @@ export default {
 
     $_bindSelfEvents(events, emitter) {
       // https://github.com/soal/vue-mapbox/blob/e0edd17bde5fe8d1db7f44029e0e3399e2bf35ea/src/components/UI/withSelfEvents.js
-      Object.keys(this.$listeners).forEach(eventName => {
+      Object.keys(this.$listeners).forEach((eventName) => {
         if (events.includes(eventName)) {
           emitter.on(eventName, this.$_emitSelfEvent);
         }


### PR DESCRIPTION
Reference rows 2 and 11 in Google Sheet "OurPlan Feature additions"

1. change "Everyone" to "Explore Planning Analytics" b4e99eba7e920fa602d87f5cadc292953727da6f
2. when close popup, the property should stop being highlighted on the map 39be2d4ea58e20645f3de00c069be83032f16f7a