### PR TITLE
Feature 64 dev index

### DIFF
--- a/docs/development/quick-start.md
+++ b/docs/development/quick-start.md
@@ -26,6 +26,9 @@
     The password is available in BitWarden under the entry `read_only @ postgresql`
 
     !!! note
+        Your WORKSTATION_LAN_IP should start with `192.` or `10.` and can be found with `hostname -I` on Linux and `ifconfig` on mac.
+
+    !!! note
         The above configuration points `DB_PORT` at **5433** because we'll be opening a tunnel from there to the online/remote database with the `kubectl port-forward` command in step 4.
 
         We use that port to avoid conflict with the local PostgreSQL instance step 5 will still spin up on the default port **5432**, but which we will be ignoring and not loading any data into.
@@ -40,7 +43,7 @@
     docker run -ti --rm -v $(pwd):/app -w /app composer:2.0 composer install
     ```
 
-4. Open a tunnel from the online PostgreSQL database to local port `5433`:
+4. Open a tunnel from the online PostgreSQL database to local port `5433` (if you modified the DB_PORT in step 2 you should change `5433` below):
 
     ```bash
     export KUBECONFIG=~/.kube/letsplan-deployer.yaml
@@ -73,3 +76,5 @@
     ```bash
     ./vendor/bin/sail yarn watch
     ```
+
+9. The server will now be running on http://localhost:7780

--- a/docs/development/quick-start.md
+++ b/docs/development/quick-start.md
@@ -77,4 +77,4 @@
     ./vendor/bin/sail yarn watch
     ```
 
-9. The server will now be running on http://localhost:7780
+9. The server will now be running on <http://localhost:7780>

--- a/resources/js/Pages/Explore/Layers.vue
+++ b/resources/js/Pages/Explore/Layers.vue
@@ -91,7 +91,7 @@ export default {
         */
         {
           label: 'Development Suitability',
-          attribute: 'dev_index',
+          attribute: 'devIndex',
           color: 'lime',
           isDialogVisible: false,
           value: true,
@@ -106,28 +106,32 @@ export default {
   },
   computed: {
     legendPips() {
-      const count = this.switches.filter(({value}) => value).length
+      const count = this.switches.filter(({ value }) => value).length;
       if (!count) {
         // neither switch is flipped, do not show legend
-        return
+        return null;
       }
-      const pips = [
-        { color: '#28CAF4' },
-        { color: '#377BF4' },
-        { color: '#311DF4' },
-        { color: '#8104F4' },
-        { color: '#C804F4' },
-      ]
-      pips.forEach((p, i) => p.name = i * 20 * count)
-      return pips
-    }
+      const colors = [
+        '#28CAF4',
+        '#377BF4',
+        '#311DF4',
+        '#8104F4',
+        '#C804F4',
+      ];
+      return colors.map((color, i) => ({
+        color,
+        name: i * 20 * count,
+      }));
+    },
   },
   methods: {
     onChange() {
-      const attributes = {}
-      this.switches.forEach(({attribute, value}) => attributes[attribute] = value)
-      this.$store.commit('updateLayers', attributes)
-    }
-  }
+      const attributes = {};
+      this.switches.forEach(({ attribute, value }) => {
+        attributes[attribute] = value;
+      });
+      this.$store.commit('updateLayers', attributes);
+    },
+  },
 };
 </script>

--- a/resources/js/Pages/Explore/Layers.vue
+++ b/resources/js/Pages/Explore/Layers.vue
@@ -1,5 +1,10 @@
 <template>
   <div>
+    <map-legend
+      v-if="legendPips"
+      class="mb-4"
+      :pips="legendPips"
+    />
     <div
       v-for="item in switches"
       :key="item.label"
@@ -11,6 +16,7 @@
         class="flex-grow-1"
         :label="item.label"
         :color="item.color"
+        @change="onChange"
       />
 
       <v-dialog v-model="item.isDialogVisible">
@@ -49,14 +55,16 @@
 </template>
 
 <script>
+import MapLegend from '../../Shared/MapLegend.vue';
 
 export default {
-
+  components: { MapLegend },
   data() {
     return {
       switches: [
         {
           label: 'Preservation',
+          attribute: 'preservation',
           color: 'teal',
           isDialogVisible: false,
           value: true,
@@ -83,6 +91,7 @@ export default {
         */
         {
           label: 'Development Suitability',
+          attribute: 'dev_index',
           color: 'lime',
           isDialogVisible: false,
           value: true,
@@ -95,5 +104,30 @@ export default {
       ],
     };
   },
+  computed: {
+    legendPips() {
+      const count = this.switches.filter(({value}) => value).length
+      if (!count) {
+        // neither switch is flipped, do not show legend
+        return
+      }
+      const pips = [
+        { color: '#28CAF4' },
+        { color: '#377BF4' },
+        { color: '#311DF4' },
+        { color: '#8104F4' },
+        { color: '#C804F4' },
+      ]
+      pips.forEach((p, i) => p.name = i * 20 * count)
+      return pips
+    }
+  },
+  methods: {
+    onChange() {
+      const attributes = {}
+      this.switches.forEach(({attribute, value}) => attributes[attribute] = value)
+      this.$store.commit('updateLayers', attributes)
+    }
+  }
 };
 </script>

--- a/resources/js/Pages/Explore/Layers.vue
+++ b/resources/js/Pages/Explore/Layers.vue
@@ -16,6 +16,7 @@
         class="flex-grow-1"
         :label="item.label"
         :color="item.color"
+        :disabled="item.disabled"
         @change="onChange"
       />
 
@@ -67,7 +68,8 @@ export default {
           attribute: 'preservation',
           color: 'teal',
           isDialogVisible: false,
-          value: true,
+          value: false,
+          disabled: true,
           tooltip: `The Preservation Index is built from our community survey <a href="/survey">here</a>.
             Go to the <a href="https://github.com/urbanSpatial/OurPlan_Methods/blob/main/README.md" target="_blank">OurPlan Methodology</a>
             to learn more about how the index is created.

--- a/resources/js/Shared/Layouts/MapSheetLayout.vue
+++ b/resources/js/Shared/Layouts/MapSheetLayout.vue
@@ -277,16 +277,16 @@ export default {
       /* eslint-disable prefer-spread */
       // const featMin = Math.min.apply(Math, features.map((f) => f.properties[propertyName] || 0));
       features.forEach((feat) => {
-        const { dev_index } = feat.properties
+        const { dev_index: devIndex } = feat.properties;
         // TODO uncomment this line to see preservation on map
-        // const preservation = (dev_index * 4357) % 100
-        const preservation = undefined
+        // const preservation = (devIndex * 4357) % 100
+        const preservation = undefined;
         const fstate = {
           rank: feat.properties.sale_price_adj || -1,
-          combined_layers: (dev_index || 0) + (preservation || 0),
+          combined_layers: (devIndex || 0) + (preservation || 0),
           preservation: preservation || -1,
-          dev_index: dev_index || -1,
-        }
+          devIndex: devIndex || -1,
+        };
         this.$refs.mapboxmap.map.setFeatureState({
           source: 'urban-areas',
           sourceLayer: 'urban-areas',

--- a/resources/js/Shared/Layouts/MapSheetLayout.vue
+++ b/resources/js/Shared/Layouts/MapSheetLayout.vue
@@ -277,12 +277,15 @@ export default {
       /* eslint-disable prefer-spread */
       // const featMin = Math.min.apply(Math, features.map((f) => f.properties[propertyName] || 0));
       features.forEach((feat) => {
-        const fstate = { rank: 0 };
-        // no scaling or ranking since using hard coded sales price breaks
-        fstate.rank = feat.properties.sale_price_adj;
-        // for non-numeric and 0 assign negative number to color appropriately
-        if (!fstate.rank) {
-          fstate.rank = -1;
+        const { dev_index } = feat.properties
+        // TODO uncomment this line to see preservation on map
+        // const preservation = (dev_index * 4357) % 100
+        const preservation = undefined
+        const fstate = {
+          rank: feat.properties.sale_price_adj || -1,
+          combined_layers: (dev_index || 0) + (preservation || 0),
+          preservation: preservation || -1,
+          dev_index: dev_index || -1,
         }
         this.$refs.mapboxmap.map.setFeatureState({
           source: 'urban-areas',

--- a/resources/js/Shared/Layouts/MapSheetLayout.vue
+++ b/resources/js/Shared/Layouts/MapSheetLayout.vue
@@ -300,7 +300,7 @@ export default {
         this.isPopupVisible = true;
         this.$refs.parcelpopup.setMapboxMap(this.$refs.mapboxmap.map);
         this.$refs.parcelpopup.setCoords(event.coords);
-        this.$refs.parcelinfo.fetchParcel(event.properties.parcel_id);
+        this.$refs.parcelinfo.fetchParcel(event.properties);
         this.$refs.mapboxmap.highlightSource(event.feature);
       }
     },

--- a/resources/js/Shared/MapboxMap.vue
+++ b/resources/js/Shared/MapboxMap.vue
@@ -73,20 +73,20 @@ export default {
 
   methods: {
     getLayerSteps() {
-      const { dev_index, preservation } = this.$store.getters.getField('layers')
+      const { devIndex, preservation } = this.$store.getters.getField('layers');
 
-      let max = 100
-      let attribute
+      let max = 100;
+      let attribute;
 
-      if (preservation && dev_index) { // both
-        max = 200
-        attribute = 'combined_layers'
+      if (preservation && devIndex) { // both
+        max = 200;
+        attribute = 'combined_layers';
       } else if (preservation) {
-        attribute = 'preservation'
-      } else if (dev_index) {
-        attribute = 'dev_index'
+        attribute = 'preservation';
+      } else if (devIndex) {
+        attribute = 'devIndex';
       } else { // neither
-        return this.colorNone
+        return this.colorNone;
       }
 
       return [
@@ -135,7 +135,7 @@ export default {
         return;
       }
       if (tiles === 'layers') {
-        this.getLayerSteps()
+        this.getLayerSteps();
         this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.getLayerSteps());
         return;
       }
@@ -253,11 +253,12 @@ export default {
         });
 
         this.showTiles(this.tiles);
-        this.$store.subscribe((mutation, state) => {
+        this.$store.subscribe((mutation) => {
+          // re-render map overlay if layers was changed
           if (mutation.type === 'updateLayers') {
-            this.showTiles(this.tiles)
+            this.showTiles(this.tiles);
           }
-        })
+        });
       });
     },
   },

--- a/resources/js/Shared/MapboxMap.vue
+++ b/resources/js/Shared/MapboxMap.vue
@@ -21,22 +21,12 @@ export default {
       colorNone: '#c0c0c0',
       colorRankSteps: [
         'step',
-        ['feature-state', 'dev_index'],
+        ['feature-state', 'rank'],
         '#c0c0c0', 0,
         '#28caf4', 150000,
         '#377bf4', 500000,
         '#311df4', 1000000,
         '#8104f4', 5000000,
-        '#c804f4',
-      ],
-      colorLayersSteps: [
-        'step',
-        ['get', 'dev_index'],
-        '#c0c0c0', 0,
-        '#28caf4', 20,
-        '#377bf4', 40,
-        '#311df4', 60,
-        '#8104f4', 80,
         '#c804f4',
       ],
       colorZoningCategories: [
@@ -82,6 +72,34 @@ export default {
   },
 
   methods: {
+    getLayerSteps() {
+      const { dev_index, preservation } = this.$store.getters.getField('layers')
+
+      let max = 100
+      let attribute
+
+      if (preservation && dev_index) { // both
+        max = 200
+        attribute = 'combined_layers'
+      } else if (preservation) {
+        attribute = 'preservation'
+      } else if (dev_index) {
+        attribute = 'dev_index'
+      } else { // neither
+        return this.colorNone
+      }
+
+      return [
+        'step',
+        ['feature-state', attribute],
+        '#c0c0c0', 0,
+        '#28caf4', 0.2 * max,
+        '#377bf4', 0.4 * max,
+        '#311df4', 0.6 * max,
+        '#8104f4', 0.8 * max,
+        '#c804f4',
+      ];
+    },
     highlightSource(feature) {
       const clickHighlightSource = this.map.getSource('click-highlight');
       clickHighlightSource.setData(feature);
@@ -117,7 +135,8 @@ export default {
         return;
       }
       if (tiles === 'layers') {
-        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorLayersSteps);
+        this.getLayerSteps()
+        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.getLayerSteps());
         return;
       }
       this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorNone);
@@ -234,6 +253,11 @@ export default {
         });
 
         this.showTiles(this.tiles);
+        this.$store.subscribe((mutation, state) => {
+          if (mutation.type === 'updateLayers') {
+            this.showTiles(this.tiles)
+          }
+        })
       });
     },
   },

--- a/resources/js/Shared/MapboxMap.vue
+++ b/resources/js/Shared/MapboxMap.vue
@@ -21,12 +21,22 @@ export default {
       colorNone: '#c0c0c0',
       colorRankSteps: [
         'step',
-        ['feature-state', 'rank'],
+        ['feature-state', 'dev_index'],
         '#c0c0c0', 0,
         '#28caf4', 150000,
         '#377bf4', 500000,
         '#311df4', 1000000,
         '#8104f4', 5000000,
+        '#c804f4',
+      ],
+      colorLayersSteps: [
+        'step',
+        ['get', 'dev_index'],
+        '#c0c0c0', 0,
+        '#28caf4', 20,
+        '#377bf4', 40,
+        '#311df4', 60,
+        '#8104f4', 80,
         '#c804f4',
       ],
       colorZoningCategories: [
@@ -104,6 +114,10 @@ export default {
       }
       if (tiles === 'construction') {
         this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorPermitsConstSteps);
+        return;
+      }
+      if (tiles === 'layers') {
+        this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorLayersSteps);
         return;
       }
       this.map.setPaintProperty('urban-areas-fill', 'fill-color', this.colorNone);

--- a/resources/js/Shared/ParcelInfo.vue
+++ b/resources/js/Shared/ParcelInfo.vue
@@ -45,6 +45,7 @@
       <div class="figure-group -scores pb-0">
         <parcel-figure
           name="Preservation"
+          :value="parcel.preservation"
           content-class="teal--text"
         />
         <!--parcel-figure
@@ -139,19 +140,21 @@ export default {
   },
 
   methods: {
-    fetchParcel({ id, dev_index }) {
+    fetchParcel({ parcel_id, dev_index, preservation }) {
       // avoid having to load the same parcel data twice in a session
-      if (this.cache[id]) {
-        this.parcel = this.cache[id];
+      if (this.cache[parcel_id]) {
+        this.parcel = this.cache[parcel_id];
         return;
       }
 
       this.loading = true;
-      window.axios.get(`/parcel/${id}`)
+      window.axios.get(`/parcel/${parcel_id}`)
         .then((response) => response.data.data).then((data) => {
-          const parcel = { id: data.id, ...data.attributes, dev_index };
+          const parcel = { id: parcel_id, ...data.attributes, dev_index, preservation };
+          // TODO uncomment next line to use dummy value for preservation
+          // parcel.preservation = (parcel.dev_index * 4357) % 100
           this.parcel = parcel;
-          this.cache[id] = parcel;
+          this.cache[parcel_id] = parcel;
         }).catch(() => {
           this.parcel = {};
         })

--- a/resources/js/Shared/ParcelInfo.vue
+++ b/resources/js/Shared/ParcelInfo.vue
@@ -45,7 +45,6 @@
       <div class="figure-group -scores pb-0">
         <parcel-figure
           name="Preservation"
-          value="0.5"
           content-class="teal--text"
         />
         <!--parcel-figure
@@ -60,7 +59,7 @@
         /-->
         <parcel-figure
           name="Development"
-          value="0.5"
+          :value="parcel.dev_index"
           content-class="lime--text text--darken-2"
         />
       </div>
@@ -140,19 +139,19 @@ export default {
   },
 
   methods: {
-    fetchParcel(parcelId) {
+    fetchParcel({ id, dev_index }) {
       // avoid having to load the same parcel data twice in a session
-      if (this.cache[parcelId]) {
-        this.parcel = this.cache[parcelId];
+      if (this.cache[id]) {
+        this.parcel = this.cache[id];
         return;
       }
 
       this.loading = true;
-      window.axios.get(`/parcel/${parcelId}`)
+      window.axios.get(`/parcel/${id}`)
         .then((response) => response.data.data).then((data) => {
-          const parcel = { id: data.id, ...data.attributes };
+          const parcel = { id: data.id, ...data.attributes, dev_index };
           this.parcel = parcel;
-          this.cache[parcelId] = parcel;
+          this.cache[id] = parcel;
         }).catch(() => {
           this.parcel = {};
         })

--- a/resources/js/Shared/ParcelInfo.vue
+++ b/resources/js/Shared/ParcelInfo.vue
@@ -60,7 +60,7 @@
         /-->
         <parcel-figure
           name="Development"
-          :value="parcel.dev_index"
+          :value="parcel.devIndex"
           content-class="lime--text text--darken-2"
         />
       </div>
@@ -140,21 +140,23 @@ export default {
   },
 
   methods: {
-    fetchParcel({ parcel_id, dev_index, preservation }) {
+    fetchParcel({ parcel_id: parcelId, dev_index: devIndex, preservation }) {
       // avoid having to load the same parcel data twice in a session
-      if (this.cache[parcel_id]) {
-        this.parcel = this.cache[parcel_id];
+      if (this.cache[parcelId]) {
+        this.parcel = this.cache[parcelId];
         return;
       }
 
       this.loading = true;
-      window.axios.get(`/parcel/${parcel_id}`)
+      window.axios.get(`/parcel/${parcelId}`)
         .then((response) => response.data.data).then((data) => {
-          const parcel = { id: parcel_id, ...data.attributes, dev_index, preservation };
+          const parcel = {
+            id: parcelId, ...data.attributes, devIndex, preservation,
+          };
           // TODO uncomment next line to use dummy value for preservation
-          // parcel.preservation = (parcel.dev_index * 4357) % 100
+          // parcel.preservation = (parcel.devIndex * 4357) % 100
           this.parcel = parcel;
-          this.cache[parcel_id] = parcel;
+          this.cache[parcelId] = parcel;
         }).catch(() => {
           this.parcel = {};
         })

--- a/resources/js/store/index.js
+++ b/resources/js/store/index.js
@@ -23,7 +23,7 @@ export default new Vuex.Store({
     },
     survey_results: null,
     submitted: false,
-    layers: { dev_index: true, preservation: true },
+    layers: { devIndex: true, preservation: true },
 
     // from letsplanorg
     exploreIsExpanded: false,
@@ -38,8 +38,9 @@ export default new Vuex.Store({
     },
     updateField,
     updateLayers(state, layers) {
-      state.layers = layers
-    }
+      // eslint-disable-next-line no-param-reassign
+      state.layers = layers;
+    },
   },
   getters: {
     getField,

--- a/resources/js/store/index.js
+++ b/resources/js/store/index.js
@@ -23,6 +23,7 @@ export default new Vuex.Store({
     },
     survey_results: null,
     submitted: false,
+    layers: { dev_index: true, preservation: true },
 
     // from letsplanorg
     exploreIsExpanded: false,
@@ -36,6 +37,9 @@ export default new Vuex.Store({
       state.survey_results = value;
     },
     updateField,
+    updateLayers(state, layers) {
+      state.layers = layers
+    }
   },
   getters: {
     getField,

--- a/resources/js/store/index.js
+++ b/resources/js/store/index.js
@@ -23,7 +23,7 @@ export default new Vuex.Store({
     },
     survey_results: null,
     submitted: false,
-    layers: { devIndex: true, preservation: true },
+    layers: { devIndex: true, preservation: false },
 
     // from letsplanorg
     exploreIsExpanded: false,


### PR DESCRIPTION
This fixes issue #64. 

* If you load the map and go to the "Planning Overlays" tab the map will render the combined dev_index + preservation score (0-200)
* Toggling either value changes the shown values.
* Because preservation is always zero, the preservation map is always empty and the combined map is always the same as the dev index, but with a higher scale. 
* To simulate random preservation, find the lines labeled `// TODO` in resources/js/Shared/Layouts/MapSheetLayout.vue and resources/js/Shared/ParcelInfo.vue and uncomment the appropriate lines to make preservation a pseudo-random value (seeded using dev_index for consistency)